### PR TITLE
Fixed large icons bug

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -89,6 +89,14 @@ function ConvertTo-Icon
         $newBitmap = New-Object Drawing.Bitmap $inputBitmap, $size
         #endregion Load Icon
 
+        #region Icon Size bound check
+        if ($width -gt 255 -or $height -gt 255) {
+            $ratio = ($height, $width | Measure-Object -Maximum).Maximum / 255
+            $width /= $ratio
+            $height /= $ratio
+        }
+        #endregion Icon Size bound check
+
         #region Save Icon                     
         $memoryStream = New-Object System.IO.MemoryStream
         $newBitmap.Save($memoryStream, [System.Drawing.Imaging.ImageFormat]::Png)


### PR DESCRIPTION
See #24

Added a section to check if the height or width is more than 255 which would overflow the byte cast. It calculates the current ratio and uses it to bring the size within bounds. 

While the icon is correctly generated, the context menu seems to ignore non-square icons and forces them to fill a square. Because of this you can also hardcode 255 in the $iconWriter width and height and it will work the same (though I think the resulting icon will then be square). I thought to leave it in case there is a way to allow non-square icons or maybe pad the empty space.