### PR TITLE
Self elevates the script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,3 @@
-#Requires -RunAsAdministrator
 #Requires -Version 6
 
 [CmdletBinding()]
@@ -9,6 +8,13 @@ param(
     [Parameter()]
     [switch] $PreRelease
 )
+
+# self elevate to run as local administrator
+if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    $arguments = "`"" + $MyInvocation.MyCommand.Definition + "`""
+    Start-Process pwsh -Verb runAs -ArgumentList $arguments
+    Break
+}
 
 function Generate-HelperScript(
         # The cache folder
@@ -467,3 +473,5 @@ Write-Host "Use $Layout layout."
 CreateMenuItems $executable $Layout $PreRelease
 
 Write-Host "Windows Terminal installed to Windows Explorer context menu."
+write-host "Press ENTER to exit..."
+Read-Host

--- a/install.ps1
+++ b/install.ps1
@@ -9,7 +9,7 @@ param(
     [switch] $PreRelease
 )
 
-# self elevate to run as local administrator
+# self elevate to run with local administrator privileges
 if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
     $arguments = "`"" + $MyInvocation.MyCommand.Definition + "`""
     Start-Process pwsh -Verb runAs -ArgumentList $arguments

--- a/uninstall.old.ps1
+++ b/uninstall.old.ps1
@@ -1,4 +1,3 @@
-#Requires -RunAsAdministrator
 #Requires -Version 6
 
 [CmdletBinding()]
@@ -9,6 +8,13 @@ param(
     [Parameter()]
     [switch] $PreRelease
 )
+
+# self elevate to run with local administrator privileges
+if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    $arguments = "`"" + $MyInvocation.MyCommand.Definition + "`""
+    Start-Process pwsh -Verb runAs -ArgumentList $arguments
+    Break
+}
 
 # Based on @nerdio01's version in https://github.com/microsoft/terminal/issues/1060
 
@@ -53,3 +59,5 @@ if ($layout -eq "Default") {
 }
 
 Write-Host "Windows Terminal uninstalled from Windows Explorer context menu."
+write-host "Press ENTER to exit..."
+Read-Host

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -9,13 +9,6 @@ param(
     [switch] $PreRelease
 )
 
-# self elevate to run with local administrator privileges
-if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-    $arguments = "`"" + $MyInvocation.MyCommand.Definition + "`""
-    Start-Process pwsh -Verb runAs -ArgumentList $arguments
-    Break
-}
-
 # Based on @nerdio01's version in https://github.com/microsoft/terminal/issues/1060
 
 if ((Get-Process -Id $pid).Path -like "*WindowsApps*") {

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -9,6 +9,13 @@ param(
     [switch] $PreRelease
 )
 
+# self elevate to run with local administrator privileges
+if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    $arguments = "`"" + $MyInvocation.MyCommand.Definition + "`""
+    Start-Process pwsh -Verb runAs -ArgumentList $arguments
+    Break
+}
+
 # Based on @nerdio01's version in https://github.com/microsoft/terminal/issues/1060
 
 if ((Get-Process -Id $pid).Path -like "*WindowsApps*") {
@@ -58,3 +65,5 @@ if ($layout -eq "Default") {
 }
 
 Write-Host "Windows Terminal uninstalled from Windows Explorer context menu."
+write-host "Press ENTER to exit..."
+Read-Host


### PR DESCRIPTION
The script will relaunch itself with elevated privileges if it is run from a non-administratrive Powershell session.
If UAC is enabled, the user will see a UAC prompt.